### PR TITLE
add casa derivation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Status|Wallet|Path and/or Script|Note
 ⚠️|BlueWallet[↗︎](https://bluewallet.io/)|`m/49'`\|`84'/0'/0'`|[EXTERNAL RECOVERY NOT DOCUMENTED]
 🛑|BRD (Bread Wallet)[↗︎](https://brd.com/)||[EXTERNAL RECOVERY NOT DOCUMENTED]
 🛑|BTC.com app[↗︎](https://btc.com/applications/app)||[EXTERNAL RECOVERY NOT DOCUMENTED]
-☠️|CasaHODL[↗︎](https://keys.casa/)|☠️2-of-3 or 3-of-5☠️|[EXTERNAL RECOVERY NOT DOCUMENTED]
+☠️|CasaHODL[↗︎](https://keys.casa/)|`m/49/0/X` (X increments with each key rotation)|[EXTERNAL RECOVERY NOT DOCUMENTED]
 🛑|Coin Wallet[↗︎](https://www.coin.space/) ||[EXTERNAL RECOVERY NOT DOCUMENTED]
 ✅|Coinomi[↗︎](https://www.coinomi.com)|`m/44'/0'/0'`|[Docs](https://coinomi.freshdesk.com/support/solutions/articles/29000009717-what-is-the-recovery-tool-and-how-do-i-export-my-private-keys-)
 🛑|Eclair Mobile[↗︎](https://github.com/ACINQ/eclair-mobile)||[EXTERNAL RECOVERY NOT DOCUMENTED]


### PR DESCRIPTION
Casa generates specific recovery instructions for each wallet with the unique extended public keys and derivation paths, but I can work on creating a more generic guide.

We currently support:

3 of 5 P2WSH
2 of 3 P2WSH
1 of 1 P2WSH

And there are a variety of setups with regard to how the keys are stored, so we'll want to have detailed instructions for each one.