### PR TITLE
Add entry for Cobovault with BTC only firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Status|Hardware Wallets|Supported Paths|BIP39 Pass|BIP174 PSBT|Note
 ✅😵👁🚸|BitBox01[↗︎](https://shiftcrypto.ch/bitbox01/)|`m/44'`\|`49'`\|`84'/0'/0'`|Required|No|[Docs](https://shiftcrypto.ch/bitbox01/wallet-sweep/), [Recovery Tool](https://github.com/digitalbitbox/html_backup)|
 ✅👁|BitBox02[↗︎](https://shiftcrypto.ch/bitbox02/)|`m/44'`\|`49'`\|`84'/0'/0'`|Optional|No|[Docs](https://guides.shiftcrypto.ch/bitbox02/advanced/backup-recovery/), [Recovery tool](https://github.com/digitalbitbox/bitbox02-backup-recovery)|
 ⚠️|CoboVault[↗︎](https://cobo.com/hardware-wallet/cobo-vault)|`m/49'/0'/0'`|Optional|No|[Docs](https://support.cobo.com/hc/en-us/articles/360046375373-Passphrase), [EXTERNAL RECOVERY NOT DOCUMENTED]
+✅|CoboVault with BTC only firmware [↗︎](https://cobo.com/hardware-wallet/cobo-vault)|`m/44'`\|`48'`\|`84'/0'/0'` |Optional|Yes|[Docs](https://support.cobo.com/hc/en-us/articles/360046375373-Passphrase), [Integration Guide](https://github.com/CoboVault/cobo-vault-docs/blob/master/Integration_guide.md)
 ✅😵|ColdCard Mk1[↗︎](https://coldcardwallet.com/)|`m/44'`\|`48'`\|`49'`\|`84'/0'/0'` + Custom|Optional|Yes|[Docs](https://coldcardwallet.com/docs/)
 ✅|ColdCard Mk2[↗︎](https://coldcardwallet.com/)|`m/44'`\|`48'`\|`84'/0'/0'` + Custom|Optional|Yes|[Docs](https://coldcardwallet.com/docs/)
 ✅|ColdCard Mk3[↗︎](https://coldcardwallet.com/)|`m/44'`\|`48'`\|`84'/0'/0'` + Custom|Optional|Yes|[Docs](https://coldcardwallet.com/docs/)


### PR DESCRIPTION
Add entry for the cobovault hardware wallet with BTC only firmware which has PSBT support and follow  slip-0132.