### PR TITLE
fix BitBox02 supported derivation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If we went to your website and couldn't find it => ☠️☠️☠️ [EXTERNAL 
 Status|Hardware Wallets|Supported Paths|BIP39 Pass|BIP174 PSBT|Note
 :---:|:---|:---:|---|---|---
 ✅😵👁🚸|BitBox01[↗︎](https://shiftcrypto.ch/bitbox01/)|`m/44'`\|`49'`\|`84'/0'/0'`|Required|No|[Docs](https://shiftcrypto.ch/bitbox01/wallet-sweep/), [Recovery Tool](https://github.com/digitalbitbox/html_backup)|
-✅👁|BitBox02[↗︎](https://shiftcrypto.ch/bitbox02/)|`m/44'`\|`49'`\|`84'/0'/0'`|Optional|No|[Docs](https://guides.shiftcrypto.ch/bitbox02/advanced/backup-recovery/), [Recovery tool](https://github.com/digitalbitbox/bitbox02-backup-recovery)|
+✅👁|BitBox02[↗︎](https://shiftcrypto.ch/bitbox02/)|`m/48'`\|`49'`\|`84'/0'/0'`|Optional|No|[Docs](https://guides.shiftcrypto.ch/bitbox02/advanced/backup-recovery/), [Recovery tool](https://github.com/digitalbitbox/bitbox02-backup-recovery)|
 ⚠️|CoboVault[↗︎](https://cobo.com/hardware-wallet/cobo-vault)|`m/49'/0'/0'`|Optional|No|[Docs](https://support.cobo.com/hc/en-us/articles/360046375373-Passphrase), [EXTERNAL RECOVERY NOT DOCUMENTED]
 ✅😵|ColdCard Mk1[↗︎](https://coldcardwallet.com/)|`m/44'`\|`48'`\|`49'`\|`84'/0'/0'` + Custom|Optional|Yes|[Docs](https://coldcardwallet.com/docs/)
 ✅|ColdCard Mk2[↗︎](https://coldcardwallet.com/)|`m/44'`\|`48'`\|`84'/0'/0'` + Custom|Optional|Yes|[Docs](https://coldcardwallet.com/docs/)


### PR DESCRIPTION
This pull request fixes/updates the supported derivation paths for the BitBox02:

* no support for signing Bitcoin legacy transactions, therefore `m/44'` is removed.
* derivation path `m/48'` added due to multisig support in Electrum and HWI
  (see https://github.com/bitcoin-core/HWI/blob/e6991c2a74ddf17b2d0ae4604505fdac5973c585/docs/bitbox02.md#strict-keypaths)

Thanks for maintaining this resource, appreciate it!