### PR TITLE
Fix wallet table header overlap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2997,3 +2997,13 @@ footer,
   background-color: var(--surface-color);
   color: var(--text-secondary);
 }
+
+/* Issue #224: sticky table headers can paint over wallet rows in Firefox/Brave.
+   Keep headers sortable, but let them scroll with each table so columns never overlap. */
+.wallet-table th,
+.wallet-table th.status-header,
+.status-header {
+  position: static !important;
+  top: auto !important;
+  z-index: auto;
+}


### PR DESCRIPTION
## Summary
- Fixes the table-header overlap reported in #224 by disabling sticky positioning on wallet table headers.
- Keeps headers sortable/clickable, but lets them scroll naturally with each table so they don't paint over wallet rows in Firefox/Brave/mobile browsers.

## Validation
- Downloaded and reviewed the issue screenshots to identify the sticky header paint overlap.
- `git diff --check`
- `python3 -m json.tool walletsrecovery.json`
- Started a local static server and verified the page serves successfully with `curl -I`.

## Visual check note
I attempted local browser screenshots with Playwright/Chromium and Firefox, but the browser process was blocked/crashed in this sandbox. The CSS change directly targets the overlapping sticky-header behavior shown in the issue screenshots.

Closes #224
