### PR TITLE
Update Krux output descriptor support

### DIFF
--- a/walletsrecovery.json
+++ b/walletsrecovery.json
@@ -974,13 +974,18 @@
             "brd": false,
             "custom": null
           },
-          "output_descriptor": "No",
+          "output_descriptor": "Yes",
           "bip39_pass": "Optional",
           "bip174_psbt": "Yes",
           "notes": {
             "docs": "https://selfcustody.github.io/krux/getting-started/usage/loading-a-mnemonic/",
+            "features": "https://selfcustody.github.io/krux/getting-started/usage/navigating-the-main-menu/#wallet-descriptor",
+            "integration_guide": "https://selfcustody.github.io/krux/getting-started/usage/setting-a-coordinator-and-signing/#step-3-load-and-backup-wallet-descriptor-multisig-only",
+            "archive": "https://github.com/selfcustody/krux/blob/main/CHANGELOG.md#save-and-load-wallet-output-descriptor-from-sd-card",
+            "text": "Krux supports wallet output descriptors: descriptors can be loaded by QR or SD card, saved/backed up to SD card, and used to verify receive/change addresses.",
             "external_recovery_documented": true
-          }
+          },
+          "last_verified": "2026-06-18"
         },
         {
           "status": "✅",


### PR DESCRIPTION
## Summary
- Updates the Krux wallet entry to mark output descriptor support as `Yes`.
- Adds Krux docs/changelog references for wallet descriptor loading, SD-card backup, and descriptor-based address verification.
- Adds a `last_verified` date for the Krux entry.

## Validation
- Confirmed the issue source in Krux's changelog and current docs.
- `python3 -m json.tool walletsrecovery.json`
- `node --check scripts.js`
- `git diff --check`

## Note
I also ran `python3 tools/link_check.py --allow-blocked`; it reported unrelated existing Blockstream 404s, but the new Krux links return 200.

Closes #226
