### PR TITLE
Update Krux BIP86 support

### DIFF
--- a/walletsrecovery.json
+++ b/walletsrecovery.json
@@ -970,7 +970,7 @@
             "bip49": false,
             "bip84": true,
             "bip48": true,
-            "bip86": false,
+            "bip86": true,
             "brd": false,
             "custom": null
           },
@@ -982,7 +982,11 @@
             "features": "https://selfcustody.github.io/krux/getting-started/usage/navigating-the-main-menu/#wallet-descriptor",
             "integration_guide": "https://selfcustody.github.io/krux/getting-started/usage/setting-a-coordinator-and-signing/#step-3-load-and-backup-wallet-descriptor-multisig-only",
             "archive": "https://github.com/selfcustody/krux/blob/main/CHANGELOG.md#save-and-load-wallet-output-descriptor-from-sd-card",
-            "text": "Krux supports wallet output descriptors: descriptors can be loaded by QR or SD card, saved/backed up to SD card, and used to verify receive/change addresses.",
+            "links": [
+              "https://github.com/selfcustody/krux/blob/main/CHANGELOG.md#taproot-and-wsh-miniscript-support",
+              "https://bitcoin.org/en/wallets/hardware/krux/"
+            ],
+            "text": "Krux supports wallet output descriptors and Taproot: BIP86 single-sig, Taproot/WSH Miniscript, descriptor loading by QR or SD card, SD-card descriptor backups, and descriptor-based receive/change address verification.",
             "external_recovery_documented": true
           },
           "last_verified": "2026-06-18"


### PR DESCRIPTION
## Summary
- Updates Krux derivation support to mark BIP86/Taproot as supported.
- Adds references for Krux Taproot + WSH Miniscript support and the Bitcoin.org Krux wallet listing.
- Expands the Krux notes to cover BIP86 single-sig, Taproot/WSH Miniscript, and existing descriptor workflow support.

## Validation
- Confirmed Krux changelog includes Taproot and WSH Miniscript support.
- Confirmed the Bitcoin.org Krux listing marks Taproot support.
- `python3 -m json.tool walletsrecovery.json`
- `node --check scripts.js`
- `git diff --check`
- Verified the two new source URLs return HTTP 200.

Closes #228
