### PR TITLE
[codex] Add Trezor Suite CoinJoin account path

### DIFF
--- a/walletsrecovery.json
+++ b/walletsrecovery.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "version": "1.0",
-    "last_updated": "2026-06-09",
+    "last_updated": "2026-06-22",
     "last_reviewed": "2026-06-02"
   },
   "icons": [
@@ -1883,6 +1883,35 @@
           },
           "availability": "current",
           "last_verified": "2026-06-02"
+        },
+        {
+          "status": "✅😵⚠️👁⑂",
+          "name": "Trezor Suite CoinJoin account",
+          "url": "https://trezor.io/trezor-suite",
+          "derivation": {
+            "bip44": false,
+            "bip49": false,
+            "bip84": false,
+            "bip48": false,
+            "bip86": false,
+            "brd": false,
+            "custom": "m/10025'/0'/0'/1'"
+          },
+          "output_descriptor": "No",
+          "bip39_pass": "Optional",
+          "bip174_psbt": "No",
+          "notes": {
+            "docs": "https://trezor.io/learn/advanced/blockchain-architecture-technologies/what-is-coinjoin",
+            "github_issue": "https://github.com/nvk/walletsrecovery.org/issues/213",
+            "links": [
+              "https://github.com/trezor/trezor-suite/blob/develop/suite-common/wallet-config/src/networksConfig.ts",
+              "https://github.com/satoshilabs/slips/blob/master/slip-0025.md"
+            ],
+            "external_recovery_documented": true,
+            "text": "Legacy Trezor Suite CoinJoin account. New CoinJoin rounds were discontinued on June 1, 2024, but existing accounts remain accessible; Trezor Suite uses the SLIP-25 P2TR account path m/10025'/0'/i'/1'."
+          },
+          "availability": "legacy",
+          "last_verified": "2026-06-22"
         },
         {
           "status": "✅",


### PR DESCRIPTION
## Summary
- Add a legacy `Trezor Suite CoinJoin account` row under `Combo HW+SW`.
- Record the SLIP-25 account path `m/10025'/0'/0'/1'` for issue #213.
- Update `last_updated` to 2026-06-22.

## Why
Issue #213 notes that Trezor Suite CoinJoin accounts use SLIP-25, P2TR, Bech32m. Trezor Suite source defines Bitcoin CoinJoin accounts as `m/10025'/0'/i'/1'`, so account 0 resolves to `m/10025'/0'/0'/1'`. Trezor also states that new CoinJoin rounds were discontinued on June 1, 2024, while existing accounts remain accessible.

## Sources
- https://github.com/nvk/walletsrecovery.org/issues/213
- https://github.com/trezor/trezor-suite/blob/develop/suite-common/wallet-config/src/networksConfig.ts
- https://github.com/satoshilabs/slips/blob/master/slip-0025.md
- https://trezor.io/learn/advanced/blockchain-architecture-technologies/what-is-coinjoin

## Validation
- `python3 -m json.tool walletsrecovery.json >/dev/null`
- `node --check scripts.js`
- `git diff --check`
- `python3 tools/link_check.py --allow-blocked` fails on pre-existing external 404s unrelated to this change: CoolWallet, Blockstream Help, Arculus support, and Blockchain.com support links.
